### PR TITLE
Add post image functionality 

### DIFF
--- a/Instagram.xcodeproj/project.pbxproj
+++ b/Instagram.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		6915EFC787CC0CED740658E8 /* Pods_Instagram_InstagramUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6CC601A8FF50C7AE13E98D8D /* Pods_Instagram_InstagramUITests.framework */; };
 		7B2FCCDB2866424B00908EFB /* ComposeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B2FCCDA2866424B00908EFB /* ComposeViewController.m */; };
 		7B2FCCDF286642CB00908EFB /* ProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B2FCCDE286642CB00908EFB /* ProfileViewController.m */; };
+		7B2FCCE328664EAA00908EFB /* Post.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B2FCCE228664EAA00908EFB /* Post.m */; };
 		7B465050285FB6CD0084930D /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B46504F285FB6CD0084930D /* AppDelegate.m */; };
 		7B465053285FB6CD0084930D /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B465052285FB6CD0084930D /* SceneDelegate.m */; };
 		7B465059285FB6CD0084930D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7B465057285FB6CD0084930D /* Main.storyboard */; };
@@ -56,6 +57,8 @@
 		7B2FCCDA2866424B00908EFB /* ComposeViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ComposeViewController.m; sourceTree = "<group>"; };
 		7B2FCCDD286642CB00908EFB /* ProfileViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProfileViewController.h; sourceTree = "<group>"; };
 		7B2FCCDE286642CB00908EFB /* ProfileViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProfileViewController.m; sourceTree = "<group>"; };
+		7B2FCCE128664EAA00908EFB /* Post.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Post.h; sourceTree = "<group>"; };
+		7B2FCCE228664EAA00908EFB /* Post.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Post.m; sourceTree = "<group>"; };
 		7B46504B285FB6CD0084930D /* Instagram.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Instagram.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B46504E285FB6CD0084930D /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7B46504F285FB6CD0084930D /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -153,6 +156,15 @@
 			path = "View Controllers";
 			sourceTree = "<group>";
 		};
+		7B2FCCE028664E7600908EFB /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				7B2FCCE128664EAA00908EFB /* Post.h */,
+				7B2FCCE228664EAA00908EFB /* Post.m */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		7B465042285FB6CD0084930D = {
 			isa = PBXGroup;
 			children = (
@@ -188,6 +200,7 @@
 				7B46505C285FB6CE0084930D /* LaunchScreen.storyboard */,
 				7B46505F285FB6CE0084930D /* Info.plist */,
 				7B465060285FB6CE0084930D /* main.m */,
+				7B2FCCE028664E7600908EFB /* Models */,
 			);
 			path = Instagram;
 			sourceTree = "<group>";
@@ -452,6 +465,7 @@
 				7B465088285FD8EB0084930D /* SignUpViewController.m in Sources */,
 				7B46508E2860362F0084930D /* HomeFeedViewController.m in Sources */,
 				7B465050285FB6CD0084930D /* AppDelegate.m in Sources */,
+				7B2FCCE328664EAA00908EFB /* Post.m in Sources */,
 				7B46508B285FDBF90084930D /* TabBarController.m in Sources */,
 				7B465061285FB6CE0084930D /* main.m in Sources */,
 				7B465053285FB6CD0084930D /* SceneDelegate.m in Sources */,

--- a/Instagram.xcworkspace/xcuserdata/irisfu.xcuserdatad/IDEFindNavigatorScopes.plist
+++ b/Instagram.xcworkspace/xcuserdata/irisfu.xcuserdatad/IDEFindNavigatorScopes.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>

--- a/Instagram/Base.lproj/Main.storyboard
+++ b/Instagram/Base.lproj/Main.storyboard
@@ -231,12 +231,16 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="16g-vC-oUA">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="image_placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="16g-vC-oUA">
                                 <rect key="frame" x="15" y="66" width="150" height="150"/>
+                                <gestureRecognizers/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="150" id="Cry-Nd-5Je"/>
                                     <constraint firstAttribute="width" secondItem="16g-vC-oUA" secondAttribute="height" multiplier="1:1" id="x1w-Us-C5D"/>
                                 </constraints>
+                                <connections>
+                                    <outletCollection property="gestureRecognizers" destination="fzo-Ud-2ys" appends="YES" id="Mxh-HL-7I7"/>
+                                </connections>
                             </imageView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Write a caption..." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="xz7-RN-rPf">
                                 <rect key="frame" x="185" y="66" width="190" height="175"/>
@@ -259,12 +263,29 @@
                     </view>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="oyB-l6-xE0">
-                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="cjL-Xw-FWe"/>
-                        <barButtonItem key="rightBarButtonItem" title="Share" id="CjC-n0-SZ4"/>
+                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="cjL-Xw-FWe">
+                            <connections>
+                                <action selector="didTapCancel:" destination="Kya-Xa-0cH" id="qQk-GE-RN8"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="Share" id="CjC-n0-SZ4">
+                            <connections>
+                                <action selector="didTapShare:" destination="Kya-Xa-0cH" id="00I-2s-ySY"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="postCaption" destination="xz7-RN-rPf" id="B1B-lo-HCK"/>
+                        <outlet property="postImage" destination="16g-vC-oUA" id="uUq-g6-uGZ"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="uGn-9R-Obm" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="fzo-Ud-2ys">
+                    <connections>
+                        <action selector="didTapImage:" destination="Kya-Xa-0cH" id="xaa-JC-2Xd"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="-223.07692307692307" y="3035.5450236966822"/>
         </scene>
@@ -343,6 +364,7 @@
     </inferredMetricsTieBreakers>
     <resources>
         <image name="feed_tab" width="25" height="25"/>
+        <image name="image_placeholder" width="375" height="375"/>
         <image name="insta_camera_btn" width="25" height="25"/>
         <image name="profile_tab" width="25" height="25"/>
         <namedColor name="AccentColor">

--- a/Instagram/Base.lproj/Main.storyboard
+++ b/Instagram/Base.lproj/Main.storyboard
@@ -239,7 +239,7 @@
                                     <constraint firstAttribute="width" secondItem="16g-vC-oUA" secondAttribute="height" multiplier="1:1" id="x1w-Us-C5D"/>
                                 </constraints>
                                 <connections>
-                                    <outletCollection property="gestureRecognizers" destination="fzo-Ud-2ys" appends="YES" id="Mxh-HL-7I7"/>
+                                    <outletCollection property="gestureRecognizers" destination="NZA-ZT-PTB" appends="YES" id="VFf-T3-dUp"/>
                                 </connections>
                             </imageView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Write a caption..." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="xz7-RN-rPf">
@@ -281,9 +281,9 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="uGn-9R-Obm" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <tapGestureRecognizer id="fzo-Ud-2ys">
+                <tapGestureRecognizer id="NZA-ZT-PTB">
                     <connections>
-                        <action selector="didTapImage:" destination="Kya-Xa-0cH" id="xaa-JC-2Xd"/>
+                        <action selector="didTapImage:" destination="Kya-Xa-0cH" id="fke-Ve-xnv"/>
                     </connections>
                 </tapGestureRecognizer>
             </objects>

--- a/Instagram/Info.plist
+++ b/Instagram/Info.plist
@@ -17,6 +17,10 @@
 					<string>SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
 					<string>Main</string>
+                    <key>NSPhotoLibraryUsageDescription</key>               <!-- added this for photo library permission -->
+                    <string>Need library access to upload images</string> <!-- added this for photo library permission -->
+                    <key>NSCameraUsageDescription</key> <!-- added this for camera permission -->
+                    <string>Need camera access to take pictures</string> <!-- added this for camera permission -->
 				</dict>
 			</array>
 		</dict>

--- a/Instagram/Info.plist
+++ b/Instagram/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Need camera access to take pictures</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Need library access to upload images</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -17,10 +21,10 @@
 					<string>SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
 					<string>Main</string>
-                    <key>NSPhotoLibraryUsageDescription</key>               <!-- added this for photo library permission -->
-                    <string>Need library access to upload images</string> <!-- added this for photo library permission -->
-                    <key>NSCameraUsageDescription</key> <!-- added this for camera permission -->
-                    <string>Need camera access to take pictures</string> <!-- added this for camera permission -->
+					<key>NSPhotoLibraryUsageDescription</key>
+					<string>Need library access to upload images</string>
+					<key>NSCameraUsageDescription</key>
+					<string>Need camera access to take pictures in this app</string>
 				</dict>
 			</array>
 		</dict>

--- a/Instagram/Models/Post.h
+++ b/Instagram/Models/Post.h
@@ -1,0 +1,29 @@
+//
+//  Post.h
+//  Instagram
+//
+//  Created by Iris Fu on 6/24/22.
+//
+
+#import <Parse/Parse.h>
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Post : PFObject<PFSubclassing>
+
+@property (nonatomic, strong) NSString *postID;
+@property (nonatomic, strong) NSString *userID;
+@property (nonatomic, strong) PFUser *author;
+
+@property (nonatomic, strong) NSString *caption;
+@property (nonatomic, strong) PFFileObject *image;
+@property (nonatomic, strong) NSNumber *likeCount;
+@property (nonatomic, strong) NSNumber *commentCount;
+
++ (void) postUserImage: ( UIImage * _Nullable )image withCaption: ( NSString * _Nullable )caption withCompletion: (PFBooleanResultBlock  _Nullable)completion;
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Instagram/Models/Post.m
+++ b/Instagram/Models/Post.m
@@ -1,0 +1,53 @@
+//
+//  Post.m
+//  Instagram
+//
+//  Created by Iris Fu on 6/24/22.
+//
+
+#import "Post.h"
+
+@implementation Post
+
+@dynamic postID;
+@dynamic userID;
+@dynamic author;
+@dynamic caption;
+@dynamic image;
+@dynamic likeCount;
+@dynamic commentCount;
+
++ (nonnull NSString *)parseClassName {
+    return @"Post";
+}
+
++ (void) postUserImage: ( UIImage * _Nullable )image withCaption: ( NSString * _Nullable )caption withCompletion: (PFBooleanResultBlock  _Nullable)completion {
+    
+    Post *newPost = [Post new];
+    newPost.image = [self getPFFileFromImage:image];
+    newPost.author = [PFUser currentUser];
+    newPost.caption = caption;
+    newPost.likeCount = @(0);
+    newPost.commentCount = @(0);
+    
+    [newPost saveInBackgroundWithBlock: completion];
+}
+
++ (PFFileObject *)getPFFileFromImage: (UIImage * _Nullable)image {
+ 
+    // check if image is not nil
+    if (!image) {
+        return nil;
+    }
+    
+    NSData *imageData = UIImagePNGRepresentation(image);
+    // get image data and check if that is not nil
+    if (!imageData) {
+        return nil;
+    }
+    
+    return [PFFileObject fileObjectWithName:@"image.png" data:imageData];
+}
+
+
+@end

--- a/Instagram/View Controllers/ComposeViewController.h
+++ b/Instagram/View Controllers/ComposeViewController.h
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ComposeViewController : UIViewController
+@interface ComposeViewController : UIViewController <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 
 @end
 

--- a/Instagram/View Controllers/ComposeViewController.m
+++ b/Instagram/View Controllers/ComposeViewController.m
@@ -20,7 +20,42 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view.
+}
+
+-(void)renderImagePicker {
+    // set up image picker
+    UIImagePickerController *imagePickerVC = [UIImagePickerController new];
+    imagePickerVC.delegate = self;
+    imagePickerVC.allowsEditing = true;
+    
+    // The Xcode simulator does not support taking pictures, so let's first check that the camera is indeed supported on the device before trying to present it.
+    if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
+        imagePickerVC.sourceType = UIImagePickerControllerSourceTypeCamera;
+    } else {
+        NSLog(@"Camera 🚫 available so we will use photo library instead");
+        imagePickerVC.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+    }
+
+    [self presentViewController:imagePickerVC animated:YES completion:nil];
+}
+
+- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary<NSString *,id> *)info {
+    // Get the image captured by the UIImagePickerController
+    UIImage *originalImage = info[UIImagePickerControllerOriginalImage];
+    UIImage *editedImage = info[UIImagePickerControllerEditedImage];
+
+    if (editedImage) {
+        [self.postImage setImage:editedImage];
+    } else {
+        [self.postImage setImage:originalImage];
+    }
+    
+    // Dismiss UIImagePickerController to go back to your original view controller
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)sharePost {
+    
 }
 
 /*
@@ -34,13 +69,15 @@
 */
 
 - (IBAction)didTapShare:(id)sender {
+    [self sharePost];
+    [self dismissViewControllerAnimated:true completion:nil];
 }
 
 - (IBAction)didTapCancel:(id)sender {
+    [self dismissViewControllerAnimated:true completion:nil];
 }
 
-- (IBAction)cancelButton:(id)sender {
-}
 - (IBAction)didTapImage:(id)sender {
+    [self renderImagePicker];
 }
 @end

--- a/Instagram/View Controllers/ComposeViewController.m
+++ b/Instagram/View Controllers/ComposeViewController.m
@@ -13,7 +13,8 @@
 - (IBAction)didTapShare:(id)sender;
 @property (weak, nonatomic) IBOutlet UITextView *postCaption;
 @property (weak, nonatomic) IBOutlet UIImageView *postImage;
-- (IBAction)didTapImage:(id)sender;
+- (IBAction)didTapImage:(UITapGestureRecognizer *)sender;
+
 
 @end
 
@@ -21,9 +22,17 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    // setup gesture recognizer
+    UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapImage:)];
+    tapGestureRecognizer.numberOfTapsRequired = 1;
+    
+    [self.view setUserInteractionEnabled:YES];
+    [self.view addGestureRecognizer:tapGestureRecognizer];
 }
 
 -(void)renderImagePicker {
+    NSLog(@"renderImagePicker method called");
     // set up image picker
     UIImagePickerController *imagePickerVC = [UIImagePickerController new];
     imagePickerVC.delegate = self;
@@ -92,15 +101,21 @@
 */
 
 - (IBAction)didTapShare:(id)sender {
+    NSLog(@"didTapShare action triggered");
     [self sharePost];
     [self dismissViewControllerAnimated:true completion:nil];
 }
 
 - (IBAction)didTapCancel:(id)sender {
+    NSLog(@"didTapCancel action triggered");
     [self dismissViewControllerAnimated:true completion:nil];
 }
 
-- (IBAction)didTapImage:(id)sender {
+
+- (IBAction)didTapImage:(UITapGestureRecognizer *)sender {
+    CGPoint location = [sender locationInView:self.view];
+    NSLog(@"didTapImage action triggered");
     [self renderImagePicker];
 }
+
 @end

--- a/Instagram/View Controllers/ComposeViewController.m
+++ b/Instagram/View Controllers/ComposeViewController.m
@@ -6,6 +6,7 @@
 //
 
 #import "ComposeViewController.h"
+#import "Post.h"
 
 @interface ComposeViewController ()
 - (IBAction)didTapCancel:(id)sender;
@@ -55,7 +56,29 @@
 }
 
 - (void)sharePost {
+    CGSize size = CGSizeMake(300, 300);
+    UIImage *resizedPostImage = [self resizeImage:self.postImage.image withSize:size];
+    [Post postUserImage:resizedPostImage withCaption:self.postCaption.text withCompletion:^(BOOL succeeded, NSError * _Nullable error) {
+        if (succeeded) {
+            NSLog(@"Successfully posted an image!");
+        } else {
+            NSLog(@"Error posting an image");
+        }
+    }];
+}
+
+- (UIImage *)resizeImage:(UIImage *)image withSize:(CGSize)size {
+    UIImageView *resizeImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, size.width, size.height)];
     
+    resizeImageView.contentMode = UIViewContentModeScaleAspectFill;
+    resizeImageView.image = image;
+    
+    UIGraphicsBeginImageContext(size);
+    [resizeImageView.layer renderInContext:UIGraphicsGetCurrentContext()];
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return newImage;
 }
 
 /*

--- a/Instagram/View Controllers/ComposeViewController.m
+++ b/Instagram/View Controllers/ComposeViewController.m
@@ -8,6 +8,11 @@
 #import "ComposeViewController.h"
 
 @interface ComposeViewController ()
+- (IBAction)didTapCancel:(id)sender;
+- (IBAction)didTapShare:(id)sender;
+@property (weak, nonatomic) IBOutlet UITextView *postCaption;
+@property (weak, nonatomic) IBOutlet UIImageView *postImage;
+- (IBAction)didTapImage:(id)sender;
 
 @end
 
@@ -28,4 +33,14 @@
 }
 */
 
+- (IBAction)didTapShare:(id)sender {
+}
+
+- (IBAction)didTapCancel:(id)sender {
+}
+
+- (IBAction)cancelButton:(id)sender {
+}
+- (IBAction)didTapImage:(id)sender {
+}
 @end


### PR DESCRIPTION
With this PR, the user can take a photo, add a caption, and post it to "Instagram". Tested that the posting is working by checking the Parse backend after hitting "share" to see that a new Post data entry with an image and caption has been created. On the simulator, when there is no camera available, the app will ask the user to select a photo from camera roll. Otherwise, on a device, the app will ask the user to take a photo.

Notes:
I initially found it hard to configure the tapping of the image to bring up the image picker view. Referring to [this page](https://guides.codepath.com/ios/Using-Gesture-Recognizers#step-1-choose-a-gesture-recognizer) on gesture recognizers ultimately helped me figure out what I was doing wrong and successfully complete this milestone. 